### PR TITLE
13 convert allow multiple metadata tags

### DIFF
--- a/pyplastimatch/pyplastimatch.py
+++ b/pyplastimatch/pyplastimatch.py
@@ -62,6 +62,7 @@ def convert(verbose = True, path_to_log_file = None, return_bash_command = False
                                           stdout = log_file, stderr = log_file,
                                           check = True)
     else:
+      # if no log file is specified, output to the default stdout and stderr
       bash_exit_status = subprocess.run(bash_command, capture_output = True, check = True)
       
     if verbose: print("... Done.")

--- a/pyplastimatch/pyplastimatch.py
+++ b/pyplastimatch/pyplastimatch.py
@@ -44,12 +44,16 @@ def convert(verbose = True, path_to_log_file = None, return_bash_command = False
   bash_command += ["plastimatch", "convert"]
   
   for key, val in kwargs.items():
-    bash_command += ["--%s"%(key), val]
+      if key == "metadata" and isinstance(val, list):
+          for meta in val:
+              bash_command += ["--metadata", str(meta)]
+      else:
+          bash_command += [f"--{key}", str(val)]
   
   if verbose:
     print("\nRunning 'plastimatch convert' with the specified arguments:")
-    for key, val in kwargs.items():
-      print("  --%s"%(key), val)
+    for arg in bash_command[2:]:
+        print(f"  {arg}")
   
   try:
     if path_to_log_file:
@@ -58,7 +62,6 @@ def convert(verbose = True, path_to_log_file = None, return_bash_command = False
                                           stdout = log_file, stderr = log_file,
                                           check = True)
     else:
-      # if no log file is specified, output to the default stdout and stderr
       bash_exit_status = subprocess.run(bash_command, capture_output = True, check = True)
       
     if verbose: print("... Done.")

--- a/pyplastimatch/pyplastimatch.py
+++ b/pyplastimatch/pyplastimatch.py
@@ -37,7 +37,8 @@ def convert(verbose = True, path_to_log_file = None, return_bash_command = False
       return_bash_command: return the executed command together with the exit status
       
       **kwargs: all the arguments parsable by 'plastimatch convert'
-      
+        Special Cases:
+            - metadata (list): If provided as a list, each item is passed as a separate `--metadata` argument.
   """
 
   bash_command = list()


### PR DESCRIPTION
The convert command now allows metadata tags to be passed as a list of strings, e.g. 

```python
convert_args = {
    "input": input_path,
    "patient-id": patient_id,
    "output-dicom": os.path.join(output_dir, patient_id),
    "metadata": [
        "0010,0030=19000101",
        "0010,0040=M"
    ]
}
pypla.convert(verbose=True, **convert_args)
```

Closes https://github.com/ImagingDataCommons/pyplastimatch/issues/13